### PR TITLE
Hotfix: Context::getLocaleResolver() function not found issue

### DIFF
--- a/Block/Display.php
+++ b/Block/Display.php
@@ -79,7 +79,8 @@ class Display extends Template
         array $data = []
     ) {
         $this->chatHelper = $context->getChatHelper();
-        $this->localeResolver = $context->getLocaleResolver();
+        // ToDo: this needs to fix
+        // $this->localeResolver = $context->getLocaleResolver();
         $this->customerSession = $customerSession;
         $this->filesystem = $context->getFilesystem();
         $this->coreFileStorageDatabase = $coreFileStorageDatabase;
@@ -200,10 +201,10 @@ class Display extends Template
         if ($this->chatHelper->getLanguage() == 'auto') {
             return null;
         }
-
-        if ($this->chatHelper->getLanguage() == 'md') {
-            return "\$zopim.livechat.setLanguage('" . substr($this->localeResolver->getLocale(), 0, 2) . "');" . "\n";
-        }
+        // ToDo: this needs to fix
+        // if ($this->chatHelper->getLanguage() == 'md') {
+        //     return "\$zopim.livechat.setLanguage('" . substr($this->localeResolver->getLocale(), 0, 2) . "');" . "\n";
+        // }
 
         return "\$zopim.livechat.setLanguage('" . $this->chatHelper->getLanguage() . "');" . "\n";
     }


### PR DESCRIPTION
#Description
- Hotfix for Context::getLocaleResolver() function not found issue
- I have commented out the code to get started it correctly without above error.

Note: I have commented out the code and added a todo task. When this getLocaleResolver() function is implemented and tested it properly, we can uncomment this code.